### PR TITLE
Add execute permision to each parent folder in full path to the new Apache root

### DIFF
--- a/apachange.php
+++ b/apachange.php
@@ -51,6 +51,25 @@ else
   }
   else
   {
+    if(substr($path, -1) !== "/")
+    {
+      // End path with slash to ensure all directories are covered when updating access permisions
+      $path .= "/";
+    }
+    // Update access permision on the full path to the Apache root
+    // Fixes annoing 403 errors, which appears when apache
+    // doens't have access to the new root directory or some of it's parent directory
+    $path_offset = 0;
+    while ($path_offset !== FALSE && $path_offset < strlen($path))
+    {
+      $path_offset = strpos($path, "/", $path_offset);
+      $subpath = substr($path, 0, $path_offset + 1);
+      $path_offset++;  // Next time look for '/' starting from next character
+
+      echo "Updating access permisions for: ".$subpath."\n";
+      exec("sudo chmod +x ".$subpath);
+    }
+    
     $apache='//etc/apache2/sites-available/000-default.conf';
     $file=file_get_contents($apache);
     $pattern='/DocumentRoot/';


### PR DESCRIPTION
This extra code fixes annoing 403 errors, which appears when apache doens't have access to the new root directory or some of it's parent directory.

I faced this error on my machine when I tried to change the Apache root to another drive, and I suddenly got 403 error when trying to enter the localhost website (it was working fine before change).

I realised that the problem was I didn't have correct permission on one of the folders upper in the hierarchy (i.e. new root path was: `/media/user/ExternalDrive/localhost/`
and I was missing permissions on `/media/user`, which was hard to find, yet was the reason for the website not to load.